### PR TITLE
Expand tilde in Source::Local directories

### DIFF
--- a/docs/plugins.example.toml
+++ b/docs/plugins.example.toml
@@ -10,7 +10,7 @@ match = [
 
 # Global templates to apply by default, if a plugin doesn't provide a `use`
 # field then these will be used.
-apply = ['source', 'PATH']
+apply = ['PATH', 'source']
 
 # Custom user defined templates, the `each` field means that these will be
 # applied for all matched files.
@@ -31,5 +31,9 @@ apply = ['prompt']
 
 [plugins.zsh-autosuggestions]
 source = 'git'
-url = 'https://github.com/zsh-users/zsh-autosuggestions'
-use = ['{{ name }}.plugin.zsh']
+url = 'https://github.com/zsh-users/zsh-autosuggestions' # 'git' sources must provide the Git URL.
+use = ['{{ name }}.plugin.zsh'] # these are the filenames to match on in the plugin directory.
+
+[plugins.myplugin]
+source = 'local'
+directory = "~/.dotfiles/zsh/plugins/pyenv" # 'local' sources must provide the plugin directory.

--- a/src/error.rs
+++ b/src/error.rs
@@ -117,6 +117,11 @@ impl fmt::Display for Error {
 }
 
 impl Error {
+    /// Create a new `Error`.
+    pub(crate) fn new(kind: ErrorKind, message: String) -> Error {
+        Error { kind, message }
+    }
+
     /// Returns this `Error`'s message.
     pub fn message(&self) -> &str {
         &self.message
@@ -129,19 +134,5 @@ impl Error {
             }
         }
         false
-    }
-
-    pub(crate) fn config_git(url: &str) -> Self {
-        Error {
-            kind: ErrorKind::Config,
-            message: format!("failed to parse `{}` as a Git URL", url),
-        }
-    }
-
-    pub(crate) fn config_github(repository: &str) -> Self {
-        Error {
-            kind: ErrorKind::Config,
-            message: format!("failed to parse `{}` as a GitHub repository", repository),
-        }
     }
 }


### PR DESCRIPTION
- Also errors when the Local plugin does not exist, is not a directory, or can't be accessed.
- Update `plugins.example.toml`

Resolves #3 