### PR TITLE
Warn instead of erroring when running `source`

### DIFF
--- a/src/_macros.rs
+++ b/src/_macros.rs
@@ -1,0 +1,24 @@
+/// Generate a lazy format!.
+macro_rules! s {
+    ($($arg:tt)*) => (|| format!($($arg)*))
+}
+
+/// Return a text only `Error`.
+macro_rules! bail {
+    ($fmt:expr, $($arg:tt)+) => {
+        return Err(crate::error::Error::custom(format!($fmt, $($arg)+)));
+    };
+    ($s:tt) => {
+        return Err(crate::error::Error::custom($s.into()));
+    };
+}
+
+/// Call .into() on each element in a vec! initialization.
+macro_rules! vec_into {
+    ($($i:expr),*) => (vec![$($i.into()),*]);
+}
+
+/// Call .into() on each key and value in a hashmap! initialization.
+macro_rules! indexmap_into {
+    ($($key:expr => $value:expr),*) => (indexmap!{$($key.into() => $value.into()),*})
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,129 @@
+use std::{fmt, path::PathBuf};
+
+use ansi_term::Color;
+
+use crate::{error::Error, util::PathBufExt};
+
+/// The command that we are executing.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Command {
+    Lock,
+    Source,
+}
+
+/// The requested verbosity of output.
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+pub enum Verbosity {
+    Quiet,
+    Normal,
+    Verbose,
+}
+
+/// Global contextual information for use over the entire program.
+#[derive(Clone, Debug)]
+pub struct Context {
+    /// The current crate version.
+    pub version: &'static str,
+    /// The requested verbosity of output.
+    pub verbosity: Verbosity,
+    /// Whether to not use ANSI color codes.
+    pub no_color: bool,
+    /// The location of the home directory.
+    pub home: PathBuf,
+    /// The location of the root directory.
+    pub root: PathBuf,
+    /// The location of the config file.
+    pub config_file: PathBuf,
+    /// The location of the lock file.
+    pub lock_file: PathBuf,
+    /// The command that we are executing.
+    pub command: Command,
+    /// Whether to reinstall plugin sources.
+    pub reinstall: bool,
+    /// Whether to regenerate the plugins lock file.
+    pub relock: bool,
+}
+
+impl Default for Command {
+    fn default() -> Self {
+        Command::Source
+    }
+}
+
+impl Default for Verbosity {
+    fn default() -> Self {
+        Verbosity::Normal
+    }
+}
+
+impl Context {
+    /// Expands the tilde in the given path to the configured user's home
+    /// directory.
+    pub fn expand_tilde(&self, path: PathBuf) -> PathBuf {
+        path.expand_tilde(&self.home)
+    }
+
+    /// Replaces the home directory in the given path to a tilde.
+    pub fn replace_home<P>(&self, path: P) -> PathBuf
+    where
+        P: Into<PathBuf>,
+    {
+        path.into().replace_home(&self.home)
+    }
+
+    fn log_header(&self, header: &str, message: &dyn fmt::Display) {
+        if self.no_color {
+            eprintln!("[{}] {}", header.to_uppercase(), message);
+        } else {
+            eprintln!("{} {}", Color::Purple.bold().paint(header), message);
+        }
+    }
+
+    fn log_status(&self, status: &str, message: &dyn fmt::Display) {
+        if self.no_color {
+            eprintln!(
+                "{: >12} {}",
+                format!("[{}]", status.to_uppercase()),
+                message
+            )
+        } else {
+            eprintln!(
+                "{} {}",
+                Color::Cyan.bold().paint(format!("{: >10}", status)),
+                message
+            );
+        }
+    }
+
+    pub fn header(&self, header: &str, message: &dyn fmt::Display) {
+        if self.verbosity > Verbosity::Quiet {
+            self.log_header(header, message);
+        }
+    }
+
+    pub fn header_v(&self, header: &str, message: &dyn fmt::Display) {
+        if self.verbosity > Verbosity::Normal {
+            self.log_header(header, message);
+        }
+    }
+
+    pub fn status(&self, status: &str, message: &dyn fmt::Display) {
+        if self.verbosity > Verbosity::Quiet {
+            self.log_status(status, message);
+        }
+    }
+
+    pub fn status_v(&self, status: &str, message: &dyn fmt::Display) {
+        if self.verbosity > Verbosity::Normal {
+            self.log_status(status, message);
+        }
+    }
+
+    pub fn error(&self, error: &Error) {
+        if self.no_color {
+            eprintln!("\n[ERROR] {}", error.pretty());
+        } else {
+            eprintln!("\n{} {}", Color::Red.bold().paint("error:"), error.pretty());
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,18 +4,6 @@ use std::{error::Error as Error_, fmt, io, result};
 
 use quick_error::quick_error;
 
-/// A simple macro to generate a lazy format!.
-macro_rules! s {
-    ($($arg:tt)*) => (|| format!($($arg)*))
-}
-
-/// A simple macro to return a text only `Error`.
-macro_rules! bail {
-    ($fmt:expr, $($arg:tt)+) => {
-        return Err(crate::error::Error::custom(format!($fmt, $($arg)+)));
-    }
-}
-
 /// A custom result type to use in this crate.
 pub type Result<T> = result::Result<T, Error>;
 
@@ -183,5 +171,12 @@ impl Error {
             kind: ErrorKind::Custom,
             messages: vec![message],
         }
+    }
+
+    /// A pretty representation of this `Error`.
+    pub(crate) fn pretty(&self) -> String {
+        format!("{}", self)
+            .replace("\n", "\n  due to: ")
+            .replace("Template error: ", "")
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,17 +6,6 @@ use std::{
     time,
 };
 
-/// A macro to call .into() on each element in a vec! initialization.
-macro_rules! vec_into {
-    ($($i:expr),*) => (vec![$($i.into()),*]);
-}
-
-/// A simple macro to call .into() on each key and value in a hashmap!
-/// initialization.
-macro_rules! indexmap_into {
-    ($($key:expr => $value:expr),*) => (indexmap!{$($key.into() => $value.into()),*})
-}
-
 /// An extension trait for [`Path`] types.
 ///
 /// [`Path`]: https://doc.rust-lang.org/std/path/struct.Path.html

--- a/tests/cases/git/plugins.lock
+++ b/tests/cases/git/plugins.lock
@@ -6,8 +6,8 @@ lock_file = "{{ lock_file }}"
 
 [[plugins]]
 name = "test"
-directory = "{directory}"
-filenames = ["{filename}"]
+directory = "{{ root }}/repositories/github.com/rossmacarthur/sheldon-test"
+filenames = ["{{ root }}/repositories/github.com/rossmacarthur/sheldon-test/test.plugin.zsh"]
 apply = ["source"]
 
 [templates]

--- a/tests/cases/git_bad_url/lock.stderr
+++ b/tests/cases/git_bad_url/lock.stderr
@@ -1,0 +1,6 @@
+[LOADED] ~/plugins.toml
+    [CLONED] https://github.com/rossmacarthur/sheldon-test
+
+[ERROR] failed to install source `https://github.com/rossmacarthur/sheldon-bad-url`
+  due to: failed to git clone `https://github.com/rossmacarthur/sheldon-bad-url`
+  due to: authentication required but no callback set; class=Net (12)

--- a/tests/cases/git_bad_url/plugins.toml
+++ b/tests/cases/git_bad_url/plugins.toml
@@ -1,0 +1,5 @@
+[plugins.test]
+github = 'rossmacarthur/sheldon-test'
+
+[plugins.bad-test]
+github = 'rossmacarthur/sheldon-bad-url'

--- a/tests/cases/git_bad_url/source.stderr
+++ b/tests/cases/git_bad_url/source.stderr
@@ -1,0 +1,7 @@
+[LOADED] ~/plugins.toml
+   [CHECKED] https://github.com/rossmacarthur/sheldon-test
+  [RENDERED] test
+
+[ERROR] failed to install source `https://github.com/rossmacarthur/sheldon-bad-url`
+  due to: failed to git clone `https://github.com/rossmacarthur/sheldon-bad-url`
+  due to: authentication required but no callback set; class=Net (12)

--- a/tests/cases/git_bad_url/source.stdout
+++ b/tests/cases/git_bad_url/source.stdout
@@ -1,0 +1,1 @@
+source "{{ root }}/repositories/github.com/rossmacarthur/sheldon-test/test.plugin.zsh"

--- a/tests/cases/git_branch/plugins.lock
+++ b/tests/cases/git_branch/plugins.lock
@@ -6,8 +6,8 @@ lock_file = "{{ lock_file }}"
 
 [[plugins]]
 name = "test"
-directory = "{directory}"
-filenames = ["{filename}"]
+directory = "{{ root }}/repositories/github.com/rossmacarthur/sheldon-test"
+filenames = ["{{ root }}/repositories/github.com/rossmacarthur/sheldon-test/test.plugin.zsh"]
 apply = ["source"]
 
 [templates]

--- a/tests/cases/git_tag/plugins.lock
+++ b/tests/cases/git_tag/plugins.lock
@@ -6,8 +6,8 @@ lock_file = "{{ lock_file }}"
 
 [[plugins]]
 name = "test"
-directory = "{directory}"
-filenames = ["{filename}"]
+directory = "{{ root }}/repositories/github.com/rossmacarthur/sheldon-test"
+filenames = ["{{ root }}/repositories/github.com/rossmacarthur/sheldon-test/test.plugin.zsh"]
 apply = ["source"]
 
 [templates]


### PR DESCRIPTION
- Move the `context` module to its own file.
- Move all macros to a `_macros` module.
- Fix some tests that weren't working properly.

Resolves #52 