### PR TITLE
Use XDG base directories, if available

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,6 +60,7 @@ jobs:
       run: |
         cargo install cross
         cross test --locked --target ${{ matrix.target }}
+        cross test --locked --target ${{ matrix.target }} -- --ignored --test-threads=1
 
   readme:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,7 +60,6 @@ jobs:
       run: |
         cargo install cross
         cross test --locked --target ${{ matrix.target }}
-        cross test --locked --target ${{ matrix.target }} -- --ignored --test-threads=1
 
   readme:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ The binary will be found at `target/release/sheldon`.
 ### Initializing
 
 Sheldon works by specifying plugin information in a [TOML](https://toml.io)
-configuration file. You can initialize this file by running `sheldon init`.
+configuration file, `plugins.toml`. You can initialize this file by running
+`sheldon init`.
 
 ```sh
 sheldon init --shell bash
@@ -157,9 +158,9 @@ or
 sheldon init --shell zsh
 ```
 
-This will create the `~/.sheldon` directory with an empty `plugins.toml` file.
-You can either edit this file directly or use the provided command line
-interface to add or remove plugins.
+This will create `plugins.toml` under `~/.sheldon` or, if defined,
+`$XDG_CONFIG_HOME/sheldon`. You can either edit this file directly or use the
+provided command line interface to add or remove plugins.
 
 ### Adding a plugin
 

--- a/docs/src/Getting-started.md
+++ b/docs/src/Getting-started.md
@@ -3,7 +3,8 @@
 ## Initializing
 
 Sheldon works by specifying plugin information in a [TOML](https://toml.io)
-configuration file. You can initialize this file by running `sheldon init`.
+configuration file, `plugins.toml`. You can initialize this file by running
+`sheldon init`.
 
 ```sh
 sheldon init --shell bash
@@ -15,9 +16,9 @@ or
 sheldon init --shell zsh
 ```
 
-This will create the `~/.sheldon` directory with an empty `plugins.toml` file.
-You can either edit this file directly or use the provided command line
-interface to add or remove plugins.
+This will create `plugins.toml` under `~/.sheldon` or, if defined,
+`$XDG_CONFIG_HOME/sheldon`. You can either edit this file directly or use the
+provided command line interface to add or remove plugins.
 
 ## Adding a plugin
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -423,7 +423,6 @@ mod tests {
 
     use std::env;
     use std::iter;
-    use std::path::Path;
 
     use pretty_assertions::assert_eq;
     use structopt::clap::{crate_authors, crate_description, crate_name};
@@ -1045,103 +1044,5 @@ FLAGS:
             raw_opt_err(&["source", "--update", "--reinstall"]).kind,
             structopt::clap::ErrorKind::ArgumentConflict
         );
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    // Directory structure tests, to be run with `--test-threads=1` to prevent
-    // ENV clobbering.
-    //////////////////////////////////////////////////////////////////////////
-
-    fn dir_test_settings() -> Settings {
-        Opt::from_raw_opt(raw_opt(&["--home", "/", "lock"])).settings
-    }
-
-    fn settings_from(config: &Path, data: &Path) -> Settings {
-        let home = PathBuf::from("/");
-
-        Settings {
-            version: String::from(crate_version!()),
-            home,
-            root: config.into(),
-            config_file: config.join("plugins.toml"),
-            lock_file: data.join("plugins.lock"),
-            clone_dir: data.join("repos"),
-            download_dir: data.join("downloads"),
-        }
-    }
-
-    fn xdg_settings_from(xdg_config: &Path, xdg_data: &Path) -> Settings {
-        let config = &xdg_config.join("sheldon");
-        let data = &xdg_data.join("sheldon");
-        settings_from(config, data)
-    }
-
-    #[test]
-    #[ignore]
-    fn opt_sheldon_default_dirs() {
-        setup();
-        let home = &PathBuf::from("/");
-        let config_and_data = &home.join(".sheldon");
-
-        assert_eq!(
-            dir_test_settings(),
-            settings_from(config_and_data, config_and_data)
-        );
-    }
-
-    #[test]
-    #[ignore]
-    fn opt_xdg_defaults() {
-        setup();
-        let home = &PathBuf::from("/");
-        let config_default = &home.join(".config");
-        let data_default = &home.join(".local/share");
-        let config_custom = &home.join(".config_custom");
-        let data_custom = &home.join(".local/custom");
-        let cache_custom = &home.join(".cache_custom");
-
-        env::set_var("XDG_CACHE_HOME", cache_custom);
-        assert_eq!(
-            dir_test_settings(),
-            xdg_settings_from(config_default, data_default)
-        );
-
-        env::remove_var("XDG_CACHE_HOME");
-        env::set_var("XDG_CONFIG_HOME", config_custom);
-        assert_eq!(
-            dir_test_settings(),
-            xdg_settings_from(config_custom, data_default)
-        );
-
-        env::set_var("XDG_DATA_HOME", data_custom);
-        assert_eq!(
-            dir_test_settings(),
-            xdg_settings_from(config_custom, data_custom)
-        );
-
-        env::remove_var("XDG_CONFIG_HOME");
-        assert_eq!(
-            dir_test_settings(),
-            xdg_settings_from(config_default, data_custom)
-        );
-
-        env::remove_var("XDG_DATA_HOME");
-    }
-
-    #[test]
-    #[ignore]
-    fn opt_xdg_from_env() {
-        setup();
-        let home = &PathBuf::from("/");
-        let xdg_config = &home.join(".config_custom");
-        let xdg_data = &home.join(".local/custom");
-
-        env::set_var("XDG_CONFIG_HOME", xdg_config);
-        env::set_var("XDG_DATA_HOME", xdg_data);
-
-        assert_eq!(dir_test_settings(), xdg_settings_from(xdg_config, xdg_data));
-
-        env::remove_var("XDG_CONFIG_HOME");
-        env::remove_var("XDG_DATA_HOME");
     }
 }

--- a/tests/cases/clean
+++ b/tests/cases/clean
@@ -2,12 +2,12 @@
 
 # plugins.lock
 version = "<version>"
-home = "<root>"
+home = "<home>"
 root = "<root>"
-config_file = "<root>/plugins.toml"
-lock_file = "<root>/plugins.lock"
-clone_dir = "<root>/repos"
-download_dir = "<root>/downloads"
+config_file = "<config>/plugins.toml"
+lock_file = "<data>/plugins.lock"
+clone_dir = "<data>/repos"
+download_dir = "<data>/downloads"
 plugins = []
 [templates.PATH]
 value = "export PATH=\"{{ dir }}:$PATH\""
@@ -28,13 +28,13 @@ each = true
 # lock.stdout
 
 # lock.stderr
-[LOADED] ~/plugins.toml
-   [REMOVED] ~/repos/test.com
-[LOCKED] ~/plugins.lock
+[LOADED] ~/<config_sub>/plugins.toml
+   [REMOVED] ~/.sheldon/repos/test.com
+[LOCKED] ~/<data_sub>/plugins.lock
 
 # source.stdout
 
 # source.stderr
-[UNLOCKED] ~/plugins.lock
+[UNLOCKED] ~/<data_sub>/plugins.lock
 
 # end

--- a/tests/cases/clean_permission_denied
+++ b/tests/cases/clean_permission_denied
@@ -2,12 +2,12 @@
 
 # plugins.lock
 version = "<version>"
-home = "<root>"
+home = "<home>"
 root = "<root>"
-config_file = "<root>/plugins.toml"
-lock_file = "<root>/plugins.lock"
-clone_dir = "<root>/repos"
-download_dir = "<root>/downloads"
+config_file = "<config>/plugins.toml"
+lock_file = "<data>/plugins.lock"
+clone_dir = "<data>/repos"
+download_dir = "<data>/downloads"
 plugins = []
 [templates.PATH]
 value = "export PATH=\"{{ dir }}:$PATH\""
@@ -28,15 +28,15 @@ each = true
 # lock.stdout
 
 # lock.stderr
-[LOADED] ~/plugins.toml
-[LOCKED] ~/plugins.lock
+[LOADED] ~/<config_sub>/plugins.toml
+[LOCKED] ~/<data_sub>/plugins.lock
 
-[WARNING] failed to remove directory `~/repos/test.com`
+[WARNING] failed to remove directory `~/.sheldon/repos/test.com`
   due to: Permission denied (os error 13)
 
 # source.stdout
 
 # source.stderr
-[UNLOCKED] ~/plugins.lock
+[UNLOCKED] ~/<data_sub>/plugins.lock
 
 # end

--- a/tests/cases/directories
+++ b/tests/cases/directories
@@ -1,0 +1,49 @@
+# plugins.toml
+[plugins.test_downloads]
+remote = "https://raw.githubusercontent.com/rossmacarthur/sheldon-test/master/test.plugin.zsh"
+
+# plugins.lock
+version = "<version>"
+home = "<home>"
+root = "<root>"
+config_file = "<config>/plugins.toml"
+lock_file = "<data>/plugins.lock"
+clone_dir = "<data>/repos"
+download_dir = "<data>/downloads"
+
+[[plugins]]
+name = "test_downloads"
+source_dir = "<data>/downloads/raw.githubusercontent.com/rossmacarthur/sheldon-test/master"
+files = ["<data>/downloads/raw.githubusercontent.com/rossmacarthur/sheldon-test/master/test.plugin.zsh"]
+apply = ["source"]
+[templates.PATH]
+value = "export PATH=\"{{ dir }}:$PATH\""
+each = false
+
+[templates.path]
+value = "path=( \"{{ dir }}\" $path )"
+each = false
+
+[templates.fpath]
+value = "fpath=( \"{{ dir }}\" $fpath )"
+each = false
+
+[templates.source]
+value = "source \"{{ file }}\""
+each = true
+
+# lock.stdout
+
+# lock.stderr
+[LOADED] ~/<config_sub>/plugins.toml
+   [FETCHED] https://raw.githubusercontent.com/rossmacarthur/sheldon-test/master/test.plugin.zsh
+[LOCKED] ~/<data_sub>/plugins.lock
+
+# source.stdout
+source "<data>/downloads/raw.githubusercontent.com/rossmacarthur/sheldon-test/master/test.plugin.zsh"
+
+# source.stderr
+[UNLOCKED] ~/<data_sub>/plugins.lock
+  [RENDERED] test_downloads
+
+# end

--- a/tests/cases/directories_incremental
+++ b/tests/cases/directories_incremental
@@ -1,9 +1,9 @@
 # plugins.toml
-[plugins.test_repos]
-github = "rossmacarthur/sheldon-test"
-
 [plugins.test_downloads]
 remote = "https://raw.githubusercontent.com/rossmacarthur/sheldon-test/master/test.plugin.zsh"
+
+[plugins.test_repos]
+github = "rossmacarthur/sheldon-test"
 
 # plugins.lock
 version = "<version>"
@@ -15,15 +15,15 @@ clone_dir = "<data>/repos"
 download_dir = "<data>/downloads"
 
 [[plugins]]
-name = "test_repos"
-source_dir = "<data>/repos/github.com/rossmacarthur/sheldon-test"
-files = ["<data>/repos/github.com/rossmacarthur/sheldon-test/test.plugin.zsh"]
-apply = ["source"]
-
-[[plugins]]
 name = "test_downloads"
 source_dir = "<data>/downloads/raw.githubusercontent.com/rossmacarthur/sheldon-test/master"
 files = ["<data>/downloads/raw.githubusercontent.com/rossmacarthur/sheldon-test/master/test.plugin.zsh"]
+apply = ["source"]
+
+[[plugins]]
+name = "test_repos"
+source_dir = "<data>/repos/github.com/rossmacarthur/sheldon-test"
+files = ["<data>/repos/github.com/rossmacarthur/sheldon-test/test.plugin.zsh"]
 apply = ["source"]
 [templates.PATH]
 value = "export PATH=\"{{ dir }}:$PATH\""
@@ -45,17 +45,17 @@ each = true
 
 # lock.stderr
 [LOADED] ~/<config_sub>/plugins.toml
-   [FETCHED] https://raw.githubusercontent.com/rossmacarthur/sheldon-test/master/test.plugin.zsh
+   [CHECKED] https://raw.githubusercontent.com/rossmacarthur/sheldon-test/master/test.plugin.zsh
     [CLONED] https://github.com/rossmacarthur/sheldon-test
 [LOCKED] ~/<data_sub>/plugins.lock
 
 # source.stdout
-source "<data>/repos/github.com/rossmacarthur/sheldon-test/test.plugin.zsh"
 source "<data>/downloads/raw.githubusercontent.com/rossmacarthur/sheldon-test/master/test.plugin.zsh"
+source "<data>/repos/github.com/rossmacarthur/sheldon-test/test.plugin.zsh"
 
 # source.stderr
 [UNLOCKED] ~/<data_sub>/plugins.lock
-  [RENDERED] test_repos
   [RENDERED] test_downloads
+  [RENDERED] test_repos
 
 # end

--- a/tests/cases/directory_structure
+++ b/tests/cases/directory_structure
@@ -1,6 +1,9 @@
 # plugins.toml
-[plugins.test]
+[plugins.test_repos]
 github = "rossmacarthur/sheldon-test"
+
+[plugins.test_downloads]
+remote = "https://raw.githubusercontent.com/rossmacarthur/sheldon-test/master/test.plugin.zsh"
 
 # plugins.lock
 version = "<version>"
@@ -12,9 +15,15 @@ clone_dir = "<data>/repos"
 download_dir = "<data>/downloads"
 
 [[plugins]]
-name = "test"
+name = "test_repos"
 source_dir = "<data>/repos/github.com/rossmacarthur/sheldon-test"
 files = ["<data>/repos/github.com/rossmacarthur/sheldon-test/test.plugin.zsh"]
+apply = ["source"]
+
+[[plugins]]
+name = "test_downloads"
+source_dir = "<data>/downloads/raw.githubusercontent.com/rossmacarthur/sheldon-test/master"
+files = ["<data>/downloads/raw.githubusercontent.com/rossmacarthur/sheldon-test/master/test.plugin.zsh"]
 apply = ["source"]
 [templates.PATH]
 value = "export PATH=\"{{ dir }}:$PATH\""
@@ -36,14 +45,17 @@ each = true
 
 # lock.stderr
 [LOADED] ~/<config_sub>/plugins.toml
+   [FETCHED] https://raw.githubusercontent.com/rossmacarthur/sheldon-test/master/test.plugin.zsh
     [CLONED] https://github.com/rossmacarthur/sheldon-test
 [LOCKED] ~/<data_sub>/plugins.lock
 
 # source.stdout
 source "<data>/repos/github.com/rossmacarthur/sheldon-test/test.plugin.zsh"
+source "<data>/downloads/raw.githubusercontent.com/rossmacarthur/sheldon-test/master/test.plugin.zsh"
 
 # source.stderr
 [UNLOCKED] ~/<data_sub>/plugins.lock
-  [RENDERED] test
+  [RENDERED] test_repos
+  [RENDERED] test_downloads
 
 # end

--- a/tests/cases/empty
+++ b/tests/cases/empty
@@ -2,12 +2,12 @@
 
 # plugins.lock
 version = "<version>"
-home = "<root>"
+home = "<home>"
 root = "<root>"
-config_file = "<root>/plugins.toml"
-lock_file = "<root>/plugins.lock"
-clone_dir = "<root>/repos"
-download_dir = "<root>/downloads"
+config_file = "<config>/plugins.toml"
+lock_file = "<data>/plugins.lock"
+clone_dir = "<data>/repos"
+download_dir = "<data>/downloads"
 plugins = []
 [templates.PATH]
 value = "export PATH=\"{{ dir }}:$PATH\""
@@ -28,12 +28,12 @@ each = true
 # lock.stdout
 
 # lock.stderr
-[LOADED] ~/plugins.toml
-[LOCKED] ~/plugins.lock
+[LOADED] ~/<config_sub>/plugins.toml
+[LOCKED] ~/<data_sub>/plugins.lock
 
 # source.stdout
 
 # source.stderr
-[UNLOCKED] ~/plugins.lock
+[UNLOCKED] ~/<data_sub>/plugins.lock
 
 # end

--- a/tests/cases/github_bad_reinstall
+++ b/tests/cases/github_bad_reinstall
@@ -5,17 +5,17 @@ tag = "bad-tag"
 
 # plugins.lock
 version = "<version>"
-home = "<root>"
+home = "<home>"
 root = "<root>"
-config_file = "<root>/plugins.toml"
-lock_file = "<root>/plugins.lock"
-clone_dir = "<root>/repos"
-download_dir = "<root>/downloads"
+config_file = "<config>/plugins.toml"
+lock_file = "<data>/plugins.lock"
+clone_dir = "<data>/repos"
+download_dir = "<data>/downloads"
 
 [[plugins]]
 name = "test"
-source_dir = "<root>/repos/github.com/rossmacarthur/sheldon-test"
-files = ["<root>/repos/github.com/rossmacarthur/sheldon-test/test.plugin.zsh"]
+source_dir = "<data>/repos/github.com/rossmacarthur/sheldon-test"
+files = ["<data>/repos/github.com/rossmacarthur/sheldon-test/test.plugin.zsh"]
 apply = ["source"]
 [templates.PATH]
 value = "export PATH=\"{{ dir }}:$PATH\""
@@ -36,7 +36,7 @@ each = true
 # lock.stdout
 
 # lock.stderr
-[LOADED] ~/plugins.toml
+[LOADED] ~/<config_sub>/plugins.toml
 
 [ERROR] failed to install source `https://github.com/rossmacarthur/sheldon-test@bad-tag`
   due to: failed to find tag `bad-tag`

--- a/tests/cases/github_bad_url
+++ b/tests/cases/github_bad_url
@@ -8,7 +8,7 @@ github = "rossmacarthur/sheldon-bad-url"
 # lock.stdout
 
 # lock.stderr
-[LOADED] ~/plugins.toml
+[LOADED] ~/<config_sub>/plugins.toml
     [CLONED] https://github.com/rossmacarthur/sheldon-test
 
 [ERROR] failed to install source `https://github.com/rossmacarthur/sheldon-bad-url`
@@ -16,10 +16,10 @@ github = "rossmacarthur/sheldon-bad-url"
   due to: remote authentication required but none available
 
 # source.stdout
-source "<root>/repos/github.com/rossmacarthur/sheldon-test/test.plugin.zsh"
+source "<data>/repos/github.com/rossmacarthur/sheldon-test/test.plugin.zsh"
 
 # source.stderr
-[LOADED] ~/plugins.toml
+[LOADED] ~/<config_sub>/plugins.toml
    [CHECKED] https://github.com/rossmacarthur/sheldon-test
   [RENDERED] test
 

--- a/tests/cases/github_branch
+++ b/tests/cases/github_branch
@@ -5,17 +5,17 @@ branch = "feature"
 
 # plugins.lock
 version = "<version>"
-home = "<root>"
+home = "<home>"
 root = "<root>"
-config_file = "<root>/plugins.toml"
-lock_file = "<root>/plugins.lock"
-clone_dir = "<root>/repos"
-download_dir = "<root>/downloads"
+config_file = "<config>/plugins.toml"
+lock_file = "<data>/plugins.lock"
+clone_dir = "<data>/repos"
+download_dir = "<data>/downloads"
 
 [[plugins]]
 name = "test"
-source_dir = "<root>/repos/github.com/rossmacarthur/sheldon-test"
-files = ["<root>/repos/github.com/rossmacarthur/sheldon-test/test.plugin.zsh"]
+source_dir = "<data>/repos/github.com/rossmacarthur/sheldon-test"
+files = ["<data>/repos/github.com/rossmacarthur/sheldon-test/test.plugin.zsh"]
 apply = ["source"]
 [templates.PATH]
 value = "export PATH=\"{{ dir }}:$PATH\""
@@ -36,15 +36,15 @@ each = true
 # lock.stdout
 
 # lock.stderr
-[LOADED] ~/plugins.toml
+[LOADED] ~/<config_sub>/plugins.toml
     [CLONED] https://github.com/rossmacarthur/sheldon-test@feature
-[LOCKED] ~/plugins.lock
+[LOCKED] ~/<data_sub>/plugins.lock
 
 # source.stdout
-source "<root>/repos/github.com/rossmacarthur/sheldon-test/test.plugin.zsh"
+source "<data>/repos/github.com/rossmacarthur/sheldon-test/test.plugin.zsh"
 
 # source.stderr
-[UNLOCKED] ~/plugins.lock
+[UNLOCKED] ~/<data_sub>/plugins.lock
   [RENDERED] test
 
 # end

--- a/tests/cases/github_git
+++ b/tests/cases/github_git
@@ -5,17 +5,17 @@ proto = "git"
 
 # plugins.lock
 version = "<version>"
-home = "<root>"
+home = "<home>"
 root = "<root>"
-config_file = "<root>/plugins.toml"
-lock_file = "<root>/plugins.lock"
-clone_dir = "<root>/repos"
-download_dir = "<root>/downloads"
+config_file = "<config>/plugins.toml"
+lock_file = "<data>/plugins.lock"
+clone_dir = "<data>/repos"
+download_dir = "<data>/downloads"
 
 [[plugins]]
 name = "test"
-source_dir = "<root>/repos/github.com/rossmacarthur/sheldon-test"
-files = ["<root>/repos/github.com/rossmacarthur/sheldon-test/test.plugin.zsh"]
+source_dir = "<data>/repos/github.com/rossmacarthur/sheldon-test"
+files = ["<data>/repos/github.com/rossmacarthur/sheldon-test/test.plugin.zsh"]
 apply = ["source"]
 [templates.PATH]
 value = "export PATH=\"{{ dir }}:$PATH\""
@@ -36,15 +36,15 @@ each = true
 # lock.stdout
 
 # lock.stderr
-[LOADED] ~/plugins.toml
+[LOADED] ~/<config_sub>/plugins.toml
     [CLONED] git://github.com/rossmacarthur/sheldon-test
-[LOCKED] ~/plugins.lock
+[LOCKED] ~/<data_sub>/plugins.lock
 
 # source.stdout
-source "<root>/repos/github.com/rossmacarthur/sheldon-test/test.plugin.zsh"
+source "<data>/repos/github.com/rossmacarthur/sheldon-test/test.plugin.zsh"
 
 # source.stderr
-[UNLOCKED] ~/plugins.lock
+[UNLOCKED] ~/<data_sub>/plugins.lock
   [RENDERED] test
 
 # end

--- a/tests/cases/github_submodule
+++ b/tests/cases/github_submodule
@@ -6,18 +6,18 @@ dir = "self/self"
 
 # plugins.lock
 version = "<version>"
-home = "<root>"
+home = "<home>"
 root = "<root>"
-config_file = "<root>/plugins.toml"
-lock_file = "<root>/plugins.lock"
-clone_dir = "<root>/repos"
-download_dir = "<root>/downloads"
+config_file = "<config>/plugins.toml"
+lock_file = "<data>/plugins.lock"
+clone_dir = "<data>/repos"
+download_dir = "<data>/downloads"
 
 [[plugins]]
 name = "test"
-source_dir = "<root>/repos/github.com/rossmacarthur/sheldon-test"
-plugin_dir = "<root>/repos/github.com/rossmacarthur/sheldon-test/self/self"
-files = ["<root>/repos/github.com/rossmacarthur/sheldon-test/self/self/test.plugin.zsh"]
+source_dir = "<data>/repos/github.com/rossmacarthur/sheldon-test"
+plugin_dir = "<data>/repos/github.com/rossmacarthur/sheldon-test/self/self"
+files = ["<data>/repos/github.com/rossmacarthur/sheldon-test/self/self/test.plugin.zsh"]
 apply = ["source"]
 [templates.PATH]
 value = "export PATH=\"{{ dir }}:$PATH\""
@@ -38,15 +38,15 @@ each = true
 # lock.stdout
 
 # lock.stderr
-[LOADED] ~/plugins.toml
+[LOADED] ~/<config_sub>/plugins.toml
     [CLONED] https://github.com/rossmacarthur/sheldon-test@recursive-recursive
-[LOCKED] ~/plugins.lock
+[LOCKED] ~/<data_sub>/plugins.lock
 
 # source.stdout
-source "<root>/repos/github.com/rossmacarthur/sheldon-test/self/self/test.plugin.zsh"
+source "<data>/repos/github.com/rossmacarthur/sheldon-test/self/self/test.plugin.zsh"
 
 # source.stderr
-[UNLOCKED] ~/plugins.lock
+[UNLOCKED] ~/<data_sub>/plugins.lock
   [RENDERED] test
 
 # end

--- a/tests/cases/github_tag
+++ b/tests/cases/github_tag
@@ -5,17 +5,17 @@ tag = "v0.1.0"
 
 # plugins.lock
 version = "<version>"
-home = "<root>"
+home = "<home>"
 root = "<root>"
-config_file = "<root>/plugins.toml"
-lock_file = "<root>/plugins.lock"
-clone_dir = "<root>/repos"
-download_dir = "<root>/downloads"
+config_file = "<config>/plugins.toml"
+lock_file = "<data>/plugins.lock"
+clone_dir = "<data>/repos"
+download_dir = "<data>/downloads"
 
 [[plugins]]
 name = "test"
-source_dir = "<root>/repos/github.com/rossmacarthur/sheldon-test"
-files = ["<root>/repos/github.com/rossmacarthur/sheldon-test/test.plugin.zsh"]
+source_dir = "<data>/repos/github.com/rossmacarthur/sheldon-test"
+files = ["<data>/repos/github.com/rossmacarthur/sheldon-test/test.plugin.zsh"]
 apply = ["source"]
 [templates.PATH]
 value = "export PATH=\"{{ dir }}:$PATH\""
@@ -36,15 +36,15 @@ each = true
 # lock.stdout
 
 # lock.stderr
-[LOADED] ~/plugins.toml
+[LOADED] ~/<config_sub>/plugins.toml
     [CLONED] https://github.com/rossmacarthur/sheldon-test@v0.1.0
-[LOCKED] ~/plugins.lock
+[LOCKED] ~/<data_sub>/plugins.lock
 
 # source.stdout
-source "<root>/repos/github.com/rossmacarthur/sheldon-test/test.plugin.zsh"
+source "<data>/repos/github.com/rossmacarthur/sheldon-test/test.plugin.zsh"
 
 # source.stderr
-[UNLOCKED] ~/plugins.lock
+[UNLOCKED] ~/<data_sub>/plugins.lock
   [RENDERED] test
 
 # end

--- a/tests/cases/inline
+++ b/tests/cases/inline
@@ -9,12 +9,12 @@ echo 'testing...'
 
 # plugins.lock
 version = "<version>"
-home = "<root>"
+home = "<home>"
 root = "<root>"
-config_file = "<root>/plugins.toml"
-lock_file = "<root>/plugins.lock"
-clone_dir = "<root>/repos"
-download_dir = "<root>/downloads"
+config_file = "<config>/plugins.toml"
+lock_file = "<data>/plugins.lock"
+clone_dir = "<data>/repos"
+download_dir = "<data>/downloads"
 
 [[plugins]]
 name = "test"
@@ -44,17 +44,17 @@ each = true
 # lock.stdout
 
 # lock.stderr
-[LOADED] ~/plugins.toml
+[LOADED] ~/<config_sub>/plugins.toml
     [CLONED] https://github.com/rossmacarthur/sheldon-test
-[LOCKED] ~/plugins.lock
+[LOCKED] ~/<data_sub>/plugins.lock
 
 # source.stdout
-source "<root>/repos/github.com/rossmacarthur/sheldon-test/test.plugin.zsh"
+source "<data>/repos/github.com/rossmacarthur/sheldon-test/test.plugin.zsh"
 echo 'testing...'
 
 
 # source.stderr
-[UNLOCKED] ~/plugins.lock
+[UNLOCKED] ~/<data_sub>/plugins.lock
   [RENDERED] test
    [INLINED] inline-test
 

--- a/tests/cases/override_config_file
+++ b/tests/cases/override_config_file
@@ -2,12 +2,12 @@
 
 # plugins.lock
 version = "<version>"
-home = "<root>"
+home = "<home>"
 root = "<root>"
-config_file = "<root>/test.toml"
-lock_file = "<root>/plugins.lock"
-clone_dir = "<root>/repos"
-download_dir = "<root>/downloads"
+config_file = "<config>/test.toml"
+lock_file = "<data>/plugins.lock"
+clone_dir = "<data>/repos"
+download_dir = "<data>/downloads"
 plugins = []
 [templates.PATH]
 value = "export PATH=\"{{ dir }}:$PATH\""
@@ -28,12 +28,12 @@ each = true
 # lock.stdout
 
 # lock.stderr
-[LOADED] ~/test.toml
-[LOCKED] ~/plugins.lock
+[LOADED] ~/<config_sub>/test.toml
+[LOCKED] ~/<data_sub>/plugins.lock
 
 # source.stdout
 
 # source.stderr
-[UNLOCKED] ~/plugins.lock
+[UNLOCKED] ~/<data_sub>/plugins.lock
 
 # end

--- a/tests/cases/override_lock_file
+++ b/tests/cases/override_lock_file
@@ -2,12 +2,12 @@
 
 # test.lock
 version = "<version>"
-home = "<root>"
+home = "<home>"
 root = "<root>"
-config_file = "<root>/plugins.toml"
-lock_file = "<root>/test.lock"
-clone_dir = "<root>/repos"
-download_dir = "<root>/downloads"
+config_file = "<config>/plugins.toml"
+lock_file = "<data>/test.lock"
+clone_dir = "<data>/repos"
+download_dir = "<data>/downloads"
 plugins = []
 [templates.PATH]
 value = "export PATH=\"{{ dir }}:$PATH\""
@@ -28,12 +28,12 @@ each = true
 # lock.stdout
 
 # lock.stderr
-[LOADED] ~/plugins.toml
-[LOCKED] ~/test.lock
+[LOADED] ~/<config_sub>/plugins.toml
+[LOCKED] ~/<data_sub>/test.lock
 
 # source.stdout
 
 # source.stderr
-[UNLOCKED] ~/test.lock
+[UNLOCKED] ~/<data_sub>/test.lock
 
 # end

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -71,6 +71,9 @@ impl TestCommand {
         command
             .env("HOME", root.as_ref())
             .env("SHELDON_ROOT", root.as_ref())
+            .env_remove("XDG_CONFIG_HOME")
+            .env_remove("XDG_DATA_HOME")
+            .env_remove("XDG_CACHE_HOME")
             .env_remove("SHELDON_CONFIG_FILE")
             .env_remove("SHELDON_LOCK_FILE")
             .env_remove("SHELDON_CLONE_DIR")

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -6,6 +6,7 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::rc::Rc;
 
 use itertools::Itertools;
 use pest::Parser;
@@ -28,15 +29,21 @@ struct TestCommand {
 }
 
 struct TestCase {
-    root: tempfile::TempDir,
+    dirs: Directories,
     data: HashMap<String, String>,
 }
 
+#[derive(Clone)]
+/// Temporary test directories and their layout.
+struct Directories {
+    home: Rc<tempfile::TempDir>,
+    root: PathBuf,
+    config: PathBuf,
+    data: PathBuf,
+}
+
 impl TestCommand {
-    fn new<R>(root: R) -> Self
-    where
-        R: AsRef<Path>,
-    {
+    fn new(dirs: &Directories) -> Self {
         // From: https://github.com/rust-lang/cargo/blob/master/crates/cargo-test-support/src/lib.rs#L545-L558
         let bin = env::var_os("CARGO_BIN_PATH")
             .map(PathBuf::from)
@@ -69,8 +76,8 @@ impl TestCommand {
         }
 
         command
-            .env("HOME", root.as_ref())
-            .env("SHELDON_ROOT", root.as_ref())
+            .env("HOME", &dirs.home.path())
+            .env("SHELDON_ROOT", &dirs.root)
             .env_remove("XDG_CONFIG_HOME")
             .env_remove("XDG_DATA_HOME")
             .env_remove("XDG_CACHE_HOME")
@@ -102,6 +109,21 @@ impl TestCommand {
 
     fn expect_stderr(mut self, stderr: String) -> Self {
         self.expect_stderr = Some(stderr);
+        self
+    }
+
+    fn expect_success(self, case: &TestCase, arg: &str) -> Self {
+        self.expect_exit_code(0)
+            .expect_stdout(case.get(format!("{}.stdout", arg)))
+            .expect_stderr(case.get(format!("{}.stderr", arg)))
+            .arg(arg)
+    }
+
+    fn envs<'v, I>(mut self, vars: I) -> Self
+    where
+        I: IntoIterator<Item = (&'v str, PathBuf)>,
+    {
+        self.command.envs(vars);
         self
     }
 
@@ -140,36 +162,49 @@ impl TestCommand {
 impl TestCase {
     /// Load the test case with the given name.
     fn load(name: &str) -> io::Result<Self> {
-        let root = tempfile::tempdir()?;
-        Self::load_with_root(name, root)
+        let dirs = Directories::default()?;
+        Self::load_with_dirs(name, dirs)
     }
 
-    /// Load the test case in the given root directory.
-    fn load_with_root(name: &str, root: tempfile::TempDir) -> io::Result<Self> {
+    /// Load the test case in the given directories.
+    fn load_with_dirs(name: &str, dirs: Directories) -> io::Result<Self> {
         let path = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("tests/cases")
             .join(name);
         let case = &fs::read_to_string(path)?;
         let parsed = TestCaseParser::parse(Rule::case, &case).expect("failed to parse case");
+
+        let config_sub = dirs.config.strip_prefix(dirs.home.path()).unwrap();
+        let data_sub = dirs.data.strip_prefix(dirs.home.path()).unwrap();
+        let substitute = |v: String| {
+            [
+                ("<home>", dirs.home.path()),
+                ("<root>", &dirs.root),
+                ("<config>", &dirs.config),
+                ("<data>", &dirs.data),
+                ("<config_sub>", config_sub),
+                ("<data>", &dirs.data),
+                ("<data_sub>", data_sub),
+            ]
+            .iter()
+            .map(|(el, dir)| (el, dir.to_str().unwrap()))
+            .fold(v, |acc, (el, dir)| acc.replace(el, dir))
+            .replace("<version>", env!("CARGO_PKG_VERSION"))
+        };
+
         let data: HashMap<String, String> = parsed
             .filter_map(|pair| {
                 if pair.as_rule() == Rule::element {
                     pair.into_inner()
                         .map(|p| p.as_str().to_string())
                         .collect_tuple()
-                        .map(|(k, v)| {
-                            (
-                                k,
-                                v.replace("<root>", root.path().to_str().unwrap())
-                                    .replace("<version>", env!("CARGO_PKG_VERSION")),
-                            )
-                        })
+                        .map(|(k, v)| (k, substitute(v)))
                 } else {
                     None
                 }
             })
             .collect();
-        Ok(Self { root, data })
+        Ok(Self { dirs, data })
     }
 
     /// Get the value of the given key in this test case.
@@ -184,7 +219,7 @@ impl TestCase {
     }
 
     fn run_command(&self, command: &str) -> io::Result<()> {
-        TestCommand::new(self.root.path())
+        TestCommand::new(&self.dirs)
             .expect_exit_code(0)
             .expect_stdout(self.get(format!("{}.stdout", command)))
             .expect_stderr(self.get(format!("{}.stderr", command)))
@@ -192,23 +227,66 @@ impl TestCase {
             .run()
     }
 
-    fn write_file(&self, name: &str) -> io::Result<()> {
-        fs::write(&self.root.path().join(name), self.get(name))
+    fn write_config_file(&self, name: &str) -> io::Result<()> {
+        fs::write(self.dirs.config.join(name), self.get(name))
     }
 
     fn assert_contents(&self, name: &str) -> io::Result<()> {
         assert_eq!(
-            &fs::read_to_string(&self.root.path().join(name))?,
+            &fs::read_to_string(self.dirs.root.join(name))?,
             &self.get(name)
         );
         Ok(())
     }
 
     fn run(&self) -> io::Result<()> {
-        self.write_file("plugins.toml")?;
+        self.write_config_file("plugins.toml")?;
         self.run_command("lock")?;
         self.assert_contents("plugins.lock")?;
         self.run_command("source")
+    }
+}
+
+impl Directories {
+    fn conforms(&self) -> bool {
+        self.root.exists()
+            && self.config.join("plugins.toml").exists()
+            && self.data.join("plugins.lock").exists()
+            && self.data.join("repos").exists()
+            && self.data.join("downloads").exists()
+    }
+
+    fn init(self) -> io::Result<Self> {
+        fs::create_dir_all(&self.data)?;
+        fs::create_dir_all(&self.config)?;
+        Ok(self)
+    }
+
+    fn default_xdg() -> io::Result<Self> {
+        let home = Rc::new(tempfile::tempdir()?);
+        let config = home.path().join(".config").join("sheldon");
+        let data = home.path().join(".local/share").join("sheldon");
+
+        Directories {
+            home,
+            root: data.clone(),
+            config,
+            data,
+        }
+        .init()
+    }
+
+    fn default() -> io::Result<Self> {
+        let home = Rc::new(tempfile::tempdir()?);
+        let root = home.path().join(".sheldon");
+        fs::create_dir(&root)?;
+
+        Ok(Directories {
+            home,
+            config: root.clone(),
+            data: root.clone(),
+            root,
+        })
     }
 }
 
@@ -251,8 +329,8 @@ fn check_sheldon_test(root: &Path) -> Result<(), git2::Error> {
 #[test]
 fn lock_and_source_clean() -> io::Result<()> {
     let case = TestCase::load("clean")?;
-    let root = case.root.path();
-    fs::create_dir_all(&root.join("repos/test.com"))?;
+    let root = &case.dirs.root;
+    fs::create_dir_all(root.join("repos/test.com"))?;
     {
         fs::OpenOptions::new()
             .create(true)
@@ -270,13 +348,13 @@ fn lock_and_source_clean_permission_denied() -> io::Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
     let case = TestCase::load("clean_permission_denied")?;
-    let root = case.root.path();
-    fs::create_dir_all(&root.join("repos/test.com"))?;
+    let root = &case.dirs.root;
+    fs::create_dir_all(root.join("repos/test.com"))?;
     {
         fs::OpenOptions::new()
             .create(true)
             .write(true)
-            .open(&root.join("repos/test.com/test.txt"))?;
+            .open(root.join("repos/test.com/test.txt"))?;
     }
     fs::set_permissions(
         &root.join("repos/test.com"),
@@ -302,7 +380,7 @@ fn lock_and_source_empty() -> io::Result<()> {
 fn lock_and_source_github_git() -> io::Result<()> {
     let case = TestCase::load("github_git")?;
     case.run()?;
-    check_sheldon_test(case.root.path()).unwrap();
+    check_sheldon_test(&case.dirs.root).unwrap();
     Ok(())
 }
 
@@ -310,7 +388,7 @@ fn lock_and_source_github_git() -> io::Result<()> {
 fn lock_and_source_github_https() -> io::Result<()> {
     let case = TestCase::load("github_https")?;
     case.run()?;
-    check_sheldon_test(case.root.path()).unwrap();
+    check_sheldon_test(&case.dirs.root).unwrap();
     Ok(())
 }
 
@@ -321,8 +399,8 @@ fn lock_and_source_github_branch() -> io::Result<()> {
 
     // Check that sheldon-test@feature was in fact cloned.
     let dir = case
+        .dirs
         .root
-        .path()
         .join("repos/github.com/rossmacarthur/sheldon-test");
     let file = dir.join("test.plugin.zsh");
     assert!(dir.is_dir());
@@ -347,8 +425,8 @@ fn lock_and_source_github_submodule() -> io::Result<()> {
 
     // Check that sheldon-test@recursive-recursive was in fact cloned.
     let dir = case
+        .dirs
         .root
-        .path()
         .join("repos/github.com/rossmacarthur/sheldon-test");
     let file = dir.join("test.plugin.zsh");
     assert!(dir.is_dir());
@@ -397,27 +475,27 @@ fn lock_and_source_github_submodule() -> io::Result<()> {
 fn lock_and_source_github_tag() -> io::Result<()> {
     let case = TestCase::load("github_tag")?;
     case.run()?;
-    check_sheldon_test(case.root.path()).unwrap();
+    check_sheldon_test(&case.dirs.root).unwrap();
     Ok(())
 }
 
 #[test]
 fn lock_and_source_github_bad_url() -> io::Result<()> {
     let case = TestCase::load("github_bad_url")?;
-    case.write_file("plugins.toml")?;
+    case.write_config_file("plugins.toml")?;
 
-    TestCommand::new(case.root.path())
+    TestCommand::new(&case.dirs)
         .expect_exit_code(2)
         .expect_stdout(case.get("lock.stdout"))
         .expect_stderr(case.get("lock.stderr"))
         .arg("lock")
         .run()?;
 
-    assert!(!case.root.path().join("plugins.lock").exists());
+    assert!(!case.dirs.root.join("plugins.lock").exists());
 
     case.run_command("source")?;
 
-    assert!(!case.root.path().join("plugins.lock").exists());
+    assert!(!case.dirs.root.join("plugins.lock").exists());
 
     Ok(())
 }
@@ -427,12 +505,12 @@ fn lock_and_source_github_bad_reinstall() -> io::Result<()> {
     // first setup up a correct situation
     let case = TestCase::load("github_tag")?;
     case.run()?;
-    check_sheldon_test(case.root.path()).unwrap();
+    check_sheldon_test(&case.dirs.root).unwrap();
 
     // Now use a bad URL and try reinstall
-    let case = TestCase::load_with_root("github_bad_reinstall", case.root)?;
-    case.write_file("plugins.toml")?;
-    TestCommand::new(case.root.path())
+    let case = TestCase::load_with_dirs("github_bad_reinstall", case.dirs)?;
+    case.write_config_file("plugins.toml")?;
+    TestCommand::new(&case.dirs)
         .expect_exit_code(2)
         .expect_stdout(case.get("lock.stdout"))
         .expect_stderr(case.get("lock.stderr"))
@@ -441,7 +519,7 @@ fn lock_and_source_github_bad_reinstall() -> io::Result<()> {
         .run()?;
 
     // check that the previously installed plugin and lock file is okay
-    check_sheldon_test(case.root.path()).unwrap();
+    check_sheldon_test(&case.dirs.root).unwrap();
     case.assert_contents("plugins.lock")?;
 
     Ok(())
@@ -455,12 +533,12 @@ fn lock_and_source_inline() -> io::Result<()> {
 #[test]
 fn lock_and_source_override_config_file() -> io::Result<()> {
     let case = TestCase::load("override_config_file")?;
-    let config_file = case.root.path().join("test.toml");
+    let config_file = case.dirs.root.join("test.toml");
     let args = ["--config-file", config_file.to_str().unwrap()];
 
-    case.write_file("test.toml")?;
+    case.write_config_file("test.toml")?;
 
-    TestCommand::new(case.root.path())
+    TestCommand::new(&case.dirs)
         .expect_exit_code(0)
         .expect_stdout(case.get("lock.stdout"))
         .expect_stderr(case.get("lock.stderr"))
@@ -468,7 +546,7 @@ fn lock_and_source_override_config_file() -> io::Result<()> {
         .arg("lock")
         .run()?;
 
-    TestCommand::new(case.root.path())
+    TestCommand::new(&case.dirs)
         .expect_exit_code(0)
         .expect_stdout(case.get("source.stdout"))
         .expect_stderr(case.get("source.stderr"))
@@ -482,10 +560,10 @@ fn lock_and_source_override_config_file() -> io::Result<()> {
 #[test]
 fn lock_and_source_override_config_file_missing() -> io::Result<()> {
     let case = TestCase::load("override_config_file_missing")?;
-    let config_file = case.root.path().join("test.toml");
+    let config_file = case.dirs.root.join("test.toml");
     let args = ["--config-file", config_file.to_str().unwrap()];
 
-    TestCommand::new(case.root.path())
+    TestCommand::new(&case.dirs)
         .expect_exit_code(2)
         .expect_stdout(case.get("stdout"))
         .expect_stderr(case.get("stderr"))
@@ -493,7 +571,7 @@ fn lock_and_source_override_config_file_missing() -> io::Result<()> {
         .arg("lock")
         .run()?;
 
-    TestCommand::new(case.root.path())
+    TestCommand::new(&case.dirs)
         .expect_exit_code(2)
         .expect_stdout(case.get("stdout"))
         .expect_stderr(case.get("stderr"))
@@ -505,12 +583,12 @@ fn lock_and_source_override_config_file_missing() -> io::Result<()> {
 #[test]
 fn lock_and_source_override_lock_file() -> io::Result<()> {
     let case = TestCase::load("override_lock_file")?;
-    let lock_file = case.root.path().join("test.lock");
+    let lock_file = case.dirs.root.join("test.lock");
     let args = ["--lock-file", lock_file.to_str().unwrap()];
 
-    case.write_file("plugins.toml")?;
+    case.write_config_file("plugins.toml")?;
 
-    TestCommand::new(case.root.path())
+    TestCommand::new(&case.dirs)
         .expect_exit_code(0)
         .expect_stdout(case.get("lock.stdout"))
         .expect_stderr(case.get("lock.stderr"))
@@ -520,11 +598,71 @@ fn lock_and_source_override_lock_file() -> io::Result<()> {
 
     case.assert_contents("test.lock")?;
 
-    TestCommand::new(case.root.path())
+    TestCommand::new(&case.dirs)
         .expect_exit_code(0)
         .expect_stdout(case.get("source.stdout"))
         .expect_stderr(case.get("source.stderr"))
         .args(&args)
         .arg("source")
         .run()
+}
+
+#[test]
+fn dirs_default() -> io::Result<()> {
+    let dirs = Directories::default()?;
+    let case = TestCase::load_with_dirs("directory_structure", dirs.clone())?.run();
+
+    assert!(dirs.conforms());
+    assert_eq!(&dirs.data, &dirs.config);
+    case
+}
+
+#[test]
+fn dirs_xdg_default() -> io::Result<()> {
+    let dirs = Directories::default_xdg()?;
+    let case = TestCase::load_with_dirs("directory_structure", dirs.clone())?;
+    case.write_config_file("plugins.toml")?;
+
+    let env_vars = &[("XDG_CACHE_HOME", dirs.home.path().join(".cache"))];
+    TestCommand::new(&case.dirs)
+        .expect_success(&case, "lock")
+        .envs(env_vars.iter().cloned())
+        .run()?;
+    TestCommand::new(&case.dirs)
+        .expect_success(&case, "source")
+        .envs(env_vars.iter().cloned())
+        .run()?;
+
+    assert!(dirs.conforms());
+    Ok(())
+}
+
+#[test]
+fn dirs_xdg_from_env() -> io::Result<()> {
+    let home = Rc::new(tempfile::tempdir()?);
+    let xdg_config = home.path().join("config_custom");
+    let xdg_data = home.path().join(".local/custom");
+    let dirs = Directories {
+        home,
+        config: xdg_config.join("sheldon"),
+        data: xdg_data.join("sheldon"),
+        root: xdg_data.join("sheldon"),
+    }
+    .init()?;
+
+    let case = TestCase::load_with_dirs("directory_structure", dirs.clone())?;
+    case.write_config_file("plugins.toml")?;
+
+    let env_vars = &[("XDG_CONFIG_HOME", xdg_config), ("XDG_DATA_HOME", xdg_data)];
+    TestCommand::new(&case.dirs)
+        .expect_success(&case, "lock")
+        .envs(env_vars.iter().cloned())
+        .run()?;
+    TestCommand::new(&case.dirs)
+        .expect_success(&case, "source")
+        .envs(env_vars.iter().cloned())
+        .run()?;
+
+    assert!(dirs.conforms());
+    Ok(())
 }


### PR DESCRIPTION
This PR adds basic support for [XDG base directories](https://wiki.archlinux.org/index.php/XDG_Base_Directory); specifically, it makes `XDG_CONFIG_HOME/sheldon` the default root folder for Sheldon if `$XDG_CONFIG_HOME` is defined. If desired, the PR could be easily updated to make appropriate use of `XDG_DATA` as well as `XDG_CONFIG`.

There is no change in functionality: it's just a simple way to help users keep their home folders tidy. 

Two notes on the patch:
  - when determining Sheldon's root folder,`XDG_CONFIG_HOME` is simply ignored if it is not valid Unicode. Do we want to alert the user and abort instead?
  - I am not too clear on the purpose of Sheldon's `--home` flag, which is why this code still aborts if `XDG` is set but a home folder cannot be found. Does `home` serve a purpose beyond providing a prefix for the default root? In which cases would a user pass `--home` rather than `--root`?

