### PR TITLE
Adds Proxy Options in with_fetch_options function

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -268,9 +268,8 @@ pub mod git {
             ))
         });
 
-        // Creating a proxy option to, eventually, address the usage of Sheldon
-        // behind a http proxy. Using the [auto()] function to try to
-        // auto-detect the proxy from the git configuration.
+        // Try to auto-detect the proxy from the git configuration so that
+        // Sheldon can be used behind a proxy.
         let mut proxy_opts = git2::ProxyOptions::new();
         proxy_opts.auto();
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -275,7 +275,6 @@ pub mod git {
 
         let mut opts = FetchOptions::new();
         opts.remote_callbacks(rcb);
-        // adds proxy_opts to opts
         opts.proxy_options(proxy_opts);
         f(opts)
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -267,8 +267,17 @@ pub mod git {
                 "remote authentication required but none available",
             ))
         });
+
+        // Creating a proxy option to, eventually, address the usage of Sheldon
+        // behind a http proxy. Using the [auto()] function to try to
+        // auto-detect the proxy from the git configuration.
+        let mut proxy_opts = git2::ProxyOptions::new();
+        proxy_opts.auto();
+
         let mut opts = FetchOptions::new();
         opts.remote_callbacks(rcb);
+        // adds proxy_opts to opts
+        opts.proxy_options(proxy_opts);
         f(opts)
     }
 


### PR DESCRIPTION
Hi Ross, I need to use Sheldon behind an http proxy so I've had to add git2's ProxyOptions to handle this. Maybe my changes could be usefull to someone else, so my pull request...

Thanks for having create Sheldon: it is great!
claudio