### PR TITLE
Add support for cargo-binstall

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ categories = ["command-line-utilities"]
 build = "build.rs"
 include = ["src/**/*", "LICENSE-*", "README.md", "build.rs"]
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ version }/sheldon-{ version }-{ target }.tar.gz"
+
 [dependencies]
 ansi_term = "0.12.1"
 anyhow = "1.0.53"


### PR DESCRIPTION
`cargo binstall` provides an easy way to install rust binaries in opposition to building from source as `cargo install` does. That project along with [`cargo quickinstall` project](https://github.com/alsuren/cargo-quickinstall) is aiming to improve the experience that you get with the built-in `cargo install` that is way slower due to it having to first build the package and all its dependencies.

I've added support for cargo-binstall using these instructions:
https://github.com/ryankurte/cargo-binstall#supporting-binary-installation

You can test that this pkg-url works using this command:
```
cargo-binstall --pkg-url="{ repo }/releases/download/{ version }/sheldon-{ version }-{ target }.tar.gz" sheldon
```