### PR TITLE
Fix 'PermissionDenied' during rename of temporary clone directory

### DIFF
--- a/src/lock/source/git.rs
+++ b/src/lock/source/git.rs
@@ -79,9 +79,11 @@ fn checkout(
 fn install(ctx: &Context, dir: PathBuf, url: &Url, checkout: GitCheckout) -> Result<LockedSource> {
     let temp_dir =
         TempPath::new_force(&dir).context("failed to prepare temporary clone directory")?;
-    let repo = git::clone(url, temp_dir.path())?;
-    git::checkout(&repo, checkout.resolve(&repo)?)?;
-    git::submodule_update(&repo).context("failed to recursively update")?;
+    {
+        let repo = git::clone(url, temp_dir.path())?;
+        git::checkout(&repo, checkout.resolve(&repo)?)?;
+        git::submodule_update(&repo).context("failed to recursively update")?;
+    }
     temp_dir
         .rename(&dir)
         .context("failed to rename temporary clone directory")?;

--- a/src/lock/source/git.rs
+++ b/src/lock/source/git.rs
@@ -83,7 +83,7 @@ fn install(ctx: &Context, dir: PathBuf, url: &Url, checkout: GitCheckout) -> Res
         let repo = git::clone(url, temp_dir.path())?;
         git::checkout(&repo, checkout.resolve(&repo)?)?;
         git::submodule_update(&repo).context("failed to recursively update")?;
-    }
+    } // `repo` must be dropped before renaming the directory
     temp_dir
         .rename(&dir)
         .context("failed to rename temporary clone directory")?;


### PR DESCRIPTION
Call 'git_repository_free' before moving directory

```
error: failed to install source `https://github.com/zsh-users/zsh-syntax-highlighting`
  due to: failed to rename temporary clone directory
  due to: Permission denied (os error 13)
```