### PR TITLE
Fix: deprecated filter warning message

### DIFF
--- a/src/lock/script.rs
+++ b/src/lock/script.rs
@@ -109,7 +109,7 @@ impl LockedConfig {
             warnings.push(Error::msg(
                 "use of deprecated filter `get` in [templates], please use the `?.` operator \
                  instead.\nFor example: `{{ hooks | get: \"pre\" | nl }}` can be written `{{ \
-                 hook?.pre | nl }}`",
+                 hooks?.pre | nl }}`",
             ));
         }
 

--- a/tests/testdata/deprecated_get_filter/source.stderr
+++ b/tests/testdata/deprecated_get_filter/source.stderr
@@ -2,4 +2,4 @@ UNLOCKED ~/.local/share/sheldon/plugins.lock
   RENDERED test
 
 WARNING: use of deprecated filter `get` in [templates], please use the `?.` operator instead.
-For example: `{{ hooks | get: "pre" | nl }}` can be written `{{ hook?.pre | nl }}`
+For example: `{{ hooks | get: "pre" | nl }}` can be written `{{ hooks?.pre | nl }}`


### PR DESCRIPTION
## Overview
Currently, a warning message about the deprecated filter `get` is displayed as follows:
``` shell
warning: use of deprecated filter `get` in [templates], please use the `?.` operator instead.
For example: `{{ hooks | get: "pre" | nl }}` can be written `{{ hook?.pre | nl }}`
```

However, I believe `{{ hooks | get: "pre" | nl }}` can be converted to `{{ hooks?.pre | nl }}` (not `hook` but `hooks`), and I've made this adjustment.

By the way, thank you for the fantastic shell plugin manager!