### PR TITLE
Update defer template example

### DIFF
--- a/docs/src/Examples.md
+++ b/docs/src/Examples.md
@@ -27,7 +27,12 @@ Then add a template that calls `zsh-defer source` instead of just `source`.
 
 ```toml
 [templates]
-defer = "{{ hooks?.pre | nl }}{% for file in files %}zsh-defer source \"{{ file }}\"\n{% endfor %}{{ hooks?.post | nl }}"
+defer = """
+zsh-defer -c "$(cat <<'SHELDON_DEFER'
+{{ hooks?.pre | nl }}{% for file in files %}source "{{ file }}"
+{% endfor %}{{ hooks?.post | nl }}SHELDON_DEFER
+)"
+"""
 ```
 
 Now any plugin that you want to defer you can apply the `defer` template. For


### PR DESCRIPTION
Thank you for creating such a great tool!

Since I use `sheldon` daily, I noticed a couple of issues with the current `defer` template shown in the documentation:

* It invokes `zsh-defer` once per file being sourced, and each invocation of `zsh-defer` adds a small amount of overhead.
* `hooks.pre` / `hooks.post` are executed outside the `zsh-defer` context. As a result, `hooks.post` may run before the plugin is actually sourced, which can lead to counter-intuitive behavior.

With the revised example, the output generated by `sheldon` would look like this:

```zsh
zsh-defer -c "$(cat <<'SHELDON_DEFER'
echo "pre"
source "first-file"
source "second-file"
echo "post"
SHELDON_DEFER
)"
```

A here-document is used to avoid the need to escape hook contents (except the case when it include `SHELDON_DEFER` which I didn't handle).